### PR TITLE
Fix textsplitter block registration

### DIFF
--- a/Webseite/verein-menschlichkeit-theme/blocks/textsplitter-block/block.js
+++ b/Webseite/verein-menschlichkeit-theme/blocks/textsplitter-block/block.js
@@ -1,0 +1,12 @@
+import { registerBlockType } from '@wordpress/blocks';
+import './style.css';
+import './editor.css';
+import Edit from './save';
+
+registerBlockType('verein/textsplitter-block', {
+	title: 'Textsplitter Block',
+	icon: 'editor-table',
+	category: 'widgets',
+	edit: Edit,
+	save: () => null,
+});

--- a/Webseite/verein-menschlichkeit-theme/blocks/textsplitter-block/save.js
+++ b/Webseite/verein-menschlichkeit-theme/blocks/textsplitter-block/save.js
@@ -1,0 +1,3 @@
+export default function save() {
+	return null;
+}


### PR DESCRIPTION
## Summary
- implement Gutenberg registration for `textsplitter-block`
- provide a minimal save component

## Testing
- `npm run lint:js` in `blocks/textsplitter-block`

------
https://chatgpt.com/codex/tasks/task_e_685327e3a7d48329b2d11797d2b36902