### PR TITLE
Add testing guide and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: [8.1, 8.2, 8.3]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install Composer deps
+        run: composer install --prefer-dist --no-progress --no-suggest
+      - name: Static Analysis
+        run: |
+          vendor/bin/phpcs src/ || exit 1
+          vendor/bin/php-cs-fixer fix --dry-run || exit 1
+          vendor/bin/phpstan analyse src/ --level=max || exit 1
+      - name: Run PHPUnit
+        run: |
+          vendor/bin/phpunit --coverage-html coverage
+          mv coverage/index.html coverage-report.html
+      - name: Cypress Tests
+        uses: cypress-io/github-action@v6
+        with:
+          working-directory: ./
+      - name: Accessibility
+        run: npx pa11y-ci
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage-report.html
+

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "example/php-webapp",
+    "type": "project",
+    "require": {},
+    "require-dev": {
+        "phpunit/phpunit": "^10.5",
+        "squizlabs/php_codesniffer": "^3.7",
+        "friendsofphp/php-cs-fixer": "^3.50",
+        "phpstan/phpstan": "^1.10",
+        "vimeo/psalm": "^5.16"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    }
+}
+

--- a/cypress/e2e/login.cy.js
+++ b/cypress/e2e/login.cy.js
@@ -1,0 +1,7 @@
+it('logs in with valid credentials', () => {
+  cy.visit('/login');
+  cy.get('input[name=email]').type('demo@example.com');
+  cy.get('input[name=password]').type('secret{enter}');
+  cy.url().should('include', '/dashboard');
+});
+

--- a/docs/testing_overview.md
+++ b/docs/testing_overview.md
@@ -1,0 +1,65 @@
+# Testing-Strategie für PHP-Webanwendungen
+## 1 Code-Qualität & Stil
+**Ziel :** sauberen, wartbaren Code sicherstellen und Fehlerquellen frühzeitig beseitigen.  
+**Werkzeuge :** PHP_CodeSniffer, PHP-CS-Fixer, phpstan, Psalm
+**Beispiel-Befehle:**  
+```bash
+composer require --dev squizlabs/php_codesniffer friendsofphp/php-cs-fixer phpstan/phpstan
+vendor/bin/phpcs src/
+vendor/bin/php-cs-fixer fix --dry-run
+vendor/bin/phpstan analyse src/ --level=max
+```
+
+## 2 Funktionale Tests
+Unit-Tests prüfen einzelne Klassen und Methoden isoliert. Integrationstests stellen das
+Zusammenspiel mehrerer Komponenten sicher. End-to-End-Tests (E2E) simulieren komplette
+Benutzerabläufe im Browser. PHPUnit dient für Unit- und Integrationstests, während Cypress
+für automatisierte Browser-Tests eingesetzt wird.
+
+## 3 Security-Tests
+Sicherheitsprüfungen decken typische Schwachstellen wie Cross-Site-Scripting oder fehlende
+Header auf. Ein Workflow mit der OWASP ZAP CLI scannt die laufende Anwendung und meldet
+Gefahren. Zusätzlich sollten HTTP-Security-Header automatisiert kontrolliert werden.
+
+## 4 Performance & Last
+Werkzeuge wie `ab` oder `k6` messen die Belastbarkeit des Systems unter hoher
+Benutzeranzahl. Für tiefergehendes Profiling eignen sich Xdebug oder Blackfire, womit sich
+Flaschenhälse im Code gezielt finden lassen.
+
+## 5 Accessibility
+Um die Zugänglichkeit zu prüfen, kommen Lighthouse und pa11y-ci zum Einsatz. Beide Tools
+analysieren die Seite hinsichtlich Kontrast, ARIA-Rollen und Tastaturbedienbarkeit und
+liefern verwertbare Verbesserungsvorschläge.
+
+## 6 CI/CD-Pipeline
+Im CI-Workflow wird eine Matrix über PHP-Versionen 8.1 bis 8.3 definiert. Die Schritte
+umfassen Checkout, Composer-Installationen, statische Analyse, Unit-Tests, Cypress-Tests und
+abschließend Accessibility-Checks mit pa11y.
+
+```yaml
+name: ci
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: [8.1, 8.2, 8.3]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with: {php-version: ${{ matrix.php-version }}}
+      - run: composer install --no-interaction
+      - run: vendor/bin/phpstan analyse src/ --level=max
+      - run: vendor/bin/phpunit
+      - uses: cypress-io/github-action@v6
+      - run: npx pa11y-ci
+```
+
+## 7 Metriken & Grenzwerte
+| KPI                     | Grenzwert            |
+|-------------------------|----------------------|
+| Test Coverage           | ≥ 70 %               |
+| Lighthouse Performance  | > 80                 |
+| Kritische Sicherheitsfunde | 0                 |
+| Maximale Testlaufzeit   | < 10 Minuten         |

--- a/tests/InvoiceServiceTest.php
+++ b/tests/InvoiceServiceTest.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+final class InvoiceServiceTest extends TestCase {
+    public function testVatIsCalculatedCorrectly(): void {
+        $svc = new App\Service\InvoiceService();
+        $this->assertSame(120, $svc->addVat(100, 20));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add composer dev dependencies
- create sample InvoiceServiceTest
- add Cypress login test
- document testing strategy
- set up GitHub Actions workflow for PHP matrix
- refine CI workflow and docs with YAML snippet and coverage artifact

## Testing
- `php -l tests/InvoiceServiceTest.php` *(fails: command not found)*
- `composer install --no-dev --dry-run` *(command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68532cc5f7848329ae41077df72d7fc9